### PR TITLE
Add Alcallie call auditing webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Alcallie - AI Call Auditing</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+    header { background-color: #1E88E5; color: #fff; padding: 80px 20px; text-align: center; }
+    header h1 { font-size: 2.5em; margin: 0 0 10px; }
+    header p { font-size: 1.2em; margin: 0; }
+    section { padding: 60px 20px; max-width: 900px; margin: 0 auto; }
+    .comparison { background-color: #f7f7f7; }
+    h2 { color: #1E88E5; margin-top: 0; }
+    .feature-list { list-style: none; padding: 0; }
+    .feature-list li { margin: 10px 0; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Alcallie</h1>
+    <p>AI-powered call auditing for modern teams</p>
+  </header>
+
+  <section id="features">
+    <h2>AI-Based Call Auditing</h2>
+    <p>Alcallie uses advanced AI to transcribe and analyze your calls automatically. Get actionable insights, quality scores, and compliance flags in minutes.</p>
+  </section>
+
+  <section id="why-better" class="comparison">
+    <h2>Why Alcallie?</h2>
+    <ul class="feature-list">
+      <li><strong>Faster audits:</strong> instant transcripts and reports</li>
+      <li><strong>Higher accuracy:</strong> machine learning tuned for conversation analysis</li>
+      <li><strong>Easy integration:</strong> simple dashboard and flexible API</li>
+    </ul>
+  </section>
+
+  <section id="futuristic">
+    <h2>Built for the Future</h2>
+    <p>We combine dynamic voice models with real-time analytics to help you stay ahead. Our platform evolves as your business grows.</p>
+  </section>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a static `index.html` with hero area for Alcallie
- describe AI-based call auditing, a "Why Alcallie" comparison, and a future-facing section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685baf7d77c883209736341af2dcb4fd